### PR TITLE
sometimes faceIdPool don't get assigned

### DIFF
--- a/tpp/gamedir-ih/GameDir/mod/modules/InfSoldier.lua
+++ b/tpp/gamedir-ih/GameDir/mod/modules/InfSoldier.lua
@@ -793,7 +793,7 @@ function this.AddWildCards(soldierDefine,soldierSubTypes,soldierPowerSettings,so
       else
         faceIdPool=maleFaceIdPool
       end
-      if #faceIdPool==0 then
+      if faceIdPool==nil or #faceIdPool==0 then
         InfCore.Log("#faceIdPool too small, aborting",true)--DEBUG
         break
       end


### PR DESCRIPTION
i wouldn't believe it if i didn't see it myself

```
|18:19:24:958|info: TppLocation.GetLocationName
|18:19:24:958|error: .../steamapps/common/MGS_TPP/mod/modules/InfSoldier.lua:797: attempt to get length of local 'faceIdPool' (a nil value)
|18:19:24:958|info: ERROR:.../steamapps/common/MGS_TPP/mod/modules/InfSoldier.lua:797: attempt to get length of local 'faceIdPool' (a nil value)
|18:19:24:958|info: caller:.../steamapps/common/MGS_TPP/mod/modules/InfMainTpp.lua:157 - 
|18:19:24:958|info: TppQuest.RegisterQuestList
```

although probably caused by this upstream:
```
|18:22:14:995|error: ...teamapps/common/MGS_TPP/mod/modules/InfFovaIvars.lua:444: attempt to index local 'faceDef' (a nil value)
|18:22:14:995|info: ERROR:...teamapps/common/MGS_TPP/mod/modules/InfFovaIvars.lua:444: attempt to index local 'faceDef' (a nil value)
|18:22:14:995|info: caller:/Assets/tpp/script/ih/IvarProc.lua:235 - SetSetting
```